### PR TITLE
Allow for trailing newline chars in .project file

### DIFF
--- a/pipenv_pipes/utils.py
+++ b/pipenv_pipes/utils.py
@@ -54,7 +54,7 @@ def get_project_dir(project):
     project_file = get_project_path_file(project.envpath)
     try:
         with open(project_file) as fp:
-            return fp.read()
+            return fp.read().strip()
     except IOError:
         return
 


### PR DESCRIPTION
I have a slightly strange case where I'm generating the `.project` file myself using:

    echo $(pwd) > $(pipenv --venv)/.project

This is to work around https://github.com/pypa/pipenv/pull/1861

Unfortunately, this adds a newline char to the end of the project path, and ultimately, activating the project with `pipes` fails, where `pew` succeeds.

The error I get is:

    FileNotFoundError: [Errno 2] No such file or directory: '/home/charlie/code/my-project\n': '/home/charlie/code/my-project\n'


By the way -- this is a very exciting project! Thank you for making it!